### PR TITLE
fix log path error if log==False.

### DIFF
--- a/src/layout_segmentation/convert_xml.py
+++ b/src/layout_segmentation/convert_xml.py
@@ -69,7 +69,7 @@ def convert_file(path_queue: Queue, parsed_args: argparse.Namespace, target_path
     image_path = adjust_path(parsed_args.image_path) if parsed_args.image_path else None
     output_path = adjust_path(parsed_args.output_path)
     if parsed_args.log:
-        log_path = adjust_path(parsed_args.log_path) 
+        log_path = adjust_path(parsed_args.log_path)
     else:
         log_path = None
 

--- a/src/layout_segmentation/convert_xml.py
+++ b/src/layout_segmentation/convert_xml.py
@@ -68,7 +68,10 @@ def convert_file(path_queue: Queue, parsed_args: argparse.Namespace, target_path
     annotations_path = adjust_path(parsed_args.annotations_path)
     image_path = adjust_path(parsed_args.image_path) if parsed_args.image_path else None
     output_path = adjust_path(parsed_args.output_path)
-    log_path = adjust_path(parsed_args.log_path) if parsed_args.log_path else None
+    if parsed_args.log:
+        log_path = adjust_path(parsed_args.log_path) 
+    else:
+        log_path = None
 
     while True:
         path, done = path_queue.get()


### PR DESCRIPTION
Fixes the error message that `log_path` does not exist if `log==False`:
``` bash
log_path = adjust_path(parsed_args.log_path) if parsed_args.log_path else None
AttributeError: 'Namespace' object has no attribute 'log_path'
```